### PR TITLE
Add simple web test

### DIFF
--- a/src/test/java/online/aldomar/api/ScpApplicationTests.java
+++ b/src/test/java/online/aldomar/api/ScpApplicationTests.java
@@ -1,13 +1,26 @@
 package online.aldomar.api;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.ResponseEntity;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@SpringBootTest
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class ScpApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+        @Test
+        void contextLoads() {
+        }
+
+        @Test
+        void testeEndpointReturnsOk() {
+                ResponseEntity<String> response = restTemplate.getForEntity("/teste", String.class);
+                assertEquals("OK", response.getBody());
+        }
 
 }


### PR DESCRIPTION
## Summary
- run application under RANDOM_PORT for tests
- test `/teste` endpoint using TestRestTemplate

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_6854c8219f9c8332bdeebb07bd28fd8f